### PR TITLE
Remove trailing comma in example config

### DIFF
--- a/cfg/config.example.json
+++ b/cfg/config.example.json
@@ -8,5 +8,5 @@
     "staging": "aws-account-id",
     "production": "aws-account-id"
   },
-  "defaultAccount": "staging",
+  "defaultAccount": "staging"
 }


### PR DESCRIPTION
Causes the following error:

```
$ ./aws-token.sh
module.js:443
    throw err;
    ^

SyntaxError: /usr/src/app/cfg/config.json: Unexpected token }
    at Object.parse (native)
    at Object.Module._extensions..json (module.js:440:27)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/usr/src/app/src/index.js:18:16)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
```
