### PR TITLE
Support other providers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,14 +75,14 @@ function parseArgs(providerName) {
 
 function *selectRole(samlAssertion, roleName) {
   let buf = new Buffer(samlAssertion, 'base64');
-  let saml = yield thunkify(xml2js.parseString)(buf);
+  let saml = yield thunkify(xml2js.parseString)(buf, { tagNameProcessors: [xml2js.processors.stripPrefix], xmlns: true });
 
   // Extract SAML roles
   let roles;
-  let attributes = saml['saml2p:Response']['saml2:Assertion'][0]['saml2:AttributeStatement'][0]['saml2:Attribute'];
+  let attributes = saml['Response']['Assertion'][0]['AttributeStatement'][0]['Attribute'];
   for (let attribute of attributes) {
-    if (attribute['$']['Name'] === 'https://aws.amazon.com/SAML/Attributes/Role') {
-      roles = attribute['saml2:AttributeValue'].map(function(role) {
+    if (attribute['$']['Name']['value'] === 'https://aws.amazon.com/SAML/Attributes/Role') {
+      roles = attribute['AttributeValue'].map(function(role) {
         return parseRoleAttributeValue(role['_']);
       });
     }


### PR DESCRIPTION
This PR contains some fixes for supporting providers other than Okta. I ran into the following issues while trying to implement support for our corporate IdP based on PingFederate:

1. Our integration uses `RoleArn,PrincipalArn` for the values of the `https://aws.amazon.com/SAML/Attributes/Role` attribute. This is actually what [the AWS SAML docs][aws-saml] recommend. It appears the existing code was originally written to support `PrincipalArn,RoleArn`, presumably because Okta uses that.
2. Our integration uses `samlp` and `saml2` as its XML namespace prefixes, while the existing code was written to assume `saml2p` and `saml2`. My fix is to strip the prefixes in the `xml2js` processing, but it would probably be better to be more thorough about actually checking the namespace URIs and local names of each tag and attribute instead of making assumptions.

[aws-saml]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html

In addition to those two issues, which are have proposed fixes in this PR, I also thought that the handling of `accounts` and `defaultAccount` was odd. In our case, our SAML assertion in the case that a user has roles in more than one account will have all the account/role pairs as attribute values for `https://aws.amazon.com/SAML/Attributes/Role`. We do not have cross-account federation in place between the "default" account and other accounts, so it is not possible to use `AssumeRole` as this code does.

I would think that the right thing to do would actually be to present the user with a list of roles only for the chosen account when they're choosing a role. This would make sense in the case that `--account` is specified or when `defaultAccount` is set. When there is no default or user-specified account, I would think that the thing to is to show the user a list of accounts to choose from first. Either that or to present the list of roles grouped by account as is done at https://signin.aws.amazon.com/saml.

I consider this a work in progress, but I wanted to open the PR nonetheless to start some discussion.

Thanks for making such a great start on this!