### PR TITLE
fix/okta-without-mfa-hangs

### DIFF
--- a/src/providers/okta.js
+++ b/src/providers/okta.js
@@ -57,7 +57,7 @@ const Okta = {
       .type('input[name="username"]', username)
       .type('input[name="password"]', password)
       .click('input[type="submit"]') // Submit form
-      .wait('.o-form-has-errors, .mfa-verify') // Wait for error or success
+      .wait('.o-form-has-errors, .mfa-verify, #saml_form') // Wait for error or success
       .exists('.o-form-has-errors');
     spinner.stop();
 


### PR DESCRIPTION
fix: if the Okta application does not have 2FA enabled, there was a bug that hanged the script waiting for `.mfa-verify`.

When MFA is enabled the form with element `.mfa-verify` will show, otherwise, it will go directly to the `#saml_form`. 

