### PR TITLE
fix/refactor get token to improve readability

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ co(function *() {
   console.log('Earnest AWS Token Generator\n'.green.bold);
   const provider = require(`./providers/${config.provider}`);
   const args = parseArgs(provider.name);
-  const account = getSelectedAccount(args);
+  const account = getSelectedAccount(config, args);
 
   const samlAssertion = yield provider.login(config.idpEntryUrl, args.username, args.password);
   const role = yield selectRole(samlAssertion, args.role);
@@ -80,7 +80,7 @@ function parseArgs(providerName) {
   return parser.parseArgs();
 }
 
-function getSelectedAccount(args) {
+function getSelectedAccount(config, args) {
   let accountNumber = config.accounts[args.account];
   return {accountNumber, name: args.account};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const os = require('os');
 const fs = require('fs');
 const ini = require('ini');
 const path = require('path');
-const getToken = require('./token-getter');
+const TokenGetter = require('./token-getter');
 require('colors');
 
 const config = require('../cfg/config');
@@ -23,12 +23,13 @@ co(function *() {
   console.log('Earnest AWS Token Generator\n'.green.bold);
   const provider = require(`./providers/${config.provider}`);
   const args = parseArgs(provider.name);
+  const tokenGetter = new TokenGetter(config);
   const accountNumber = config.accounts[args.account];
   const account = {accountNumber, name: args.account};
 
   const samlAssertion = yield provider.login(config.idpEntryUrl, args.username, args.password);
   const role = yield selectRole(samlAssertion, args.role);
-  const token = yield getToken(config, samlAssertion, account, role);
+  const token = yield tokenGetter.getToken(samlAssertion, account, role);
   const profileName = buildProfileName(role, account.name, args.profile);
   yield writeTokenToConfig(token, profileName);
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,8 @@ co(function *() {
   console.log('Earnest AWS Token Generator\n'.green.bold);
   const provider = require(`./providers/${config.provider}`);
   const args = parseArgs(provider.name);
-  const account = getSelectedAccount(config, args);
+  const accountNumber = config.accounts[args.account];
+  const account = {accountNumber, name: args.account};
 
   const samlAssertion = yield provider.login(config.idpEntryUrl, args.username, args.password);
   const role = yield selectRole(samlAssertion, args.role);
@@ -78,11 +79,6 @@ function parseArgs(providerName) {
     'Defaults to the name of the account specified.'
   });
   return parser.parseArgs();
-}
-
-function getSelectedAccount(config, args) {
-  let accountNumber = config.accounts[args.account];
-  return {accountNumber, name: args.account};
 }
 
 function *selectRole(samlAssertion, roleName) {

--- a/src/token-getter.js
+++ b/src/token-getter.js
@@ -1,0 +1,68 @@
+'use strict';
+const AWS = require('aws-sdk');
+const clui = require('clui');
+
+class TokenGetter {
+  constructor(config, samlAssertion, account, role) {
+    this.spinner = new clui.Spinner('Getting token...');
+    this.sts = new AWS.STS({region: config.region});
+    this.samlAssertion = samlAssertion;
+    this.role = role;
+    this.account = account;
+    this.defaultAccount = config.defaultAccount;
+    this.accountNumber = this.account.accountNumber;
+  }
+
+  async getToken() {
+    try {
+      this.spinner.start();
+      const token = await this.getSTSToken();
+
+      if (this.isDefaultAccount()) {
+        this.spinner.stop();
+        return token;
+      }
+
+      // need to switch roles to the other account
+      const assumedToken = await this.getAssumeRoleToken(token);
+      this.spinner.stop();
+      return assumedToken;
+    } catch (e) {
+      console.log(e.stack); // eslint-disable-line no-console
+      throw new Error('error getting token: ' + e.message);
+    }
+  }
+
+  isDefaultAccount() {
+    return this.account.name === this.defaultAccount;
+  }
+
+  async getSTSToken() {
+    const request = this.sts.assumeRoleWithSAML({
+      PrincipalArn: this.role.principalArn,
+      RoleArn: this.role.roleArn,
+      SAMLAssertion: this.samlAssertion
+    });
+    return await request.promise();
+  }
+
+  async getAssumeRoleToken(originalToken) {
+    this.sts.config.credentials = new AWS.Credentials(
+      originalToken.Credentials.AccessKeyId,
+      originalToken.Credentials.SecretAccessKey,
+      originalToken.Credentials.SessionToken);
+    const roleArn = this.role.roleArn.replace(/::(\d+)/, `::${this.accountNumber}`);
+    const splitArn = originalToken.AssumedRoleUser.Arn.split('/');
+
+    return await this.sts.assumeRole({
+      RoleArn: roleArn,
+      RoleSessionName: splitArn[splitArn.length - 1]
+    }).promise();
+  }
+}
+
+function *getToken(config, samlAssertion, account, role) {
+  return new TokenGetter(config, samlAssertion, account, role).getToken();
+}
+
+module.exports = getToken;

--- a/src/token-getter.js
+++ b/src/token-getter.js
@@ -2,18 +2,20 @@
 const AWS = require('aws-sdk');
 const clui = require('clui');
 
+// Not thread safe!
 class TokenGetter {
-  constructor(config, samlAssertion, account, role) {
+  constructor(config) {
     this.spinner = new clui.Spinner('Getting token...');
     this.sts = new AWS.STS({region: config.region});
-    this.samlAssertion = samlAssertion;
-    this.role = role;
-    this.account = account;
     this.defaultAccount = config.defaultAccount;
-    this.accountNumber = this.account.accountNumber;
   }
 
-  async getToken() {
+  async getToken(samlAssertion, account, role) {
+    this.samlAssertion = samlAssertion;
+    this.account = account;
+    this.accountNumber = this.account.accountNumber;
+    this.role = role;
+
     try {
       this.spinner.start();
       const token = await this.getSTSToken();
@@ -61,8 +63,4 @@ class TokenGetter {
   }
 }
 
-function *getToken(config, samlAssertion, account, role) {
-  return new TokenGetter(config, samlAssertion, account, role).getToken();
-}
-
-module.exports = getToken;
+module.exports = TokenGetter;


### PR DESCRIPTION
Before: lots of nesting and a big function, with mixed high and low level details:

```
sts.assumeRoleWithSAML({	
...
}, function (err, token) {		
    sts.assumeRole({	
        if...
        if...
        ...
    }, function (err, assumedToken) {	
        if...
        ...
    });	
});
```

now is much clear what is happening there:

```
      this.spinner.start();
      const token = await this.getSTSToken();

       if (this.isDefaultAccount()) {
        this.spinner.stop();
        return token;
      }

       // need to switch roles to the other account
      const assumedToken = await this.getAssumeRoleToken(token);
      this.spinner.stop();
      return assumedToken;
```