### PR TITLE
support-iam-role-refresh-okta-setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 aws-token.sh
 config.json*
+!example/config.json

--- a/README.md
+++ b/README.md
@@ -1,63 +1,40 @@
 # AWS STS Token Generator
 
-
-Single Sign on within AWS removes the ability to generate long-lived access tokens for AWS. Instead, the 
-[Amazon Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) is used to generate 
+Single Sign on within AWS removes the ability to generate long-lived access tokens for AWS. Instead, the
+[Amazon Security Token Service](http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) is used to generate
 short-lived tokens.
 
 This command line utility can be used to authenticate with an SSO provider (ex: Okta) and generate access token credentials.
 It supports assuming an AWS role and will automatically update your AWS CLI credentials file with the new credentials.
- 
+
 For ease of use, the token generator is packaged as a docker container. Your team will not need to clone this repository
 or install anything. Token can be generated via a single `docker run` command. A helper script is also included to encapsulate
 the arguments of the docker command.
 
-We recommend the following steps for use in your organization:
-
-1. Create a fresh git repository
-2. Copy [`config.example.json`](./cfg/config.example.json) to the root of your repository as `config.json` and edit it for your organization
-3. Copy the [`aws-token.example.sh`](./aws-token.example.sh) script to the root of your repository for easy distribution/use 
-4. Create a Dockerfile for your token generator. The following should suffice:
-    
-    ```
-    FROM earnest/aws-sts
-    ```
-    
-5. Build and publish the docker image for use in your organization
-
-## Configuration
-
-Configuration is done by creating a config.json file in the root of your repository. An [example template](./cfg/config.example.json) is provided.
- 
-```
-awsConfigPath:    Path to the user AWS CLI credential file. The recommended path is the path to the Docker container's credential path.
-outputFormat:     Output format of AWS access token credentials
-region:           Region used for AWS API calls
-provider:         Name of the SAML provider to use for authentication
-idPEntryUrl:      URL to access the form-based authentication login for the provider
-defaultAccount:   Default AWS account to use when one is not specified via the command line
-accounts:         Hash of name/accountID pairs for accounts which can be switched to once initially authenticated
-```
-
-## Building
-
-Once configured, build a docker container so that folks on your team can easily generate tokens without setup or configuration.
-
-```
-docker build -t YOUR_ORG/aws-sts .
-docker push YOUR_ORG/aws-sts
-```
-
 ## Installation
 
-The token generator runs as a docker container which can bind-mount to your AWS credentials file to save temporary credentials. 
-Installation is as simple as downloading the [`aws-token.sh`](./aws-token.sh) script and saving it somewhere. Then execute that file every time 
+The token generator runs as a docker container which can bind-mount to your AWS credentials file to save temporary credentials.
+Installation is as simple as downloading the [`aws-token`](./example/aws-token) script and saving it to your prefered PATH location e.g. `/usr/local/bin/aws-token`. Then execute that file every time
 you need a new token.
+
+```
+$> aws-token
+```
+
+### Bonus: exporting the credentials as ENV vars
+
+```
+export AWS_PROFILE=<the generated profile here>
+export AWS_ACCESS_KEY_ID=$(aws configure get $AWS_PROFILE.aws_access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get $AWS_PROFILE.aws_secret_access_key)
+export AWS_SESSION_TOKEN=$(aws configure get $AWS_PROFILE.aws_session_token)
+export AWS_DEFAULT_REGION=us-east-1
+```
 
 ## Usage
 
 `````
-$> ./aws-token.sh --help
+$> aws-token --help
 usage: index.js [-h] [-v] [--username USERNAME] [--password PASSWORD]
                 [--role ROLE]
                 [--account {staging,development}]
@@ -69,7 +46,7 @@ AWS STS Token Generator
 Optional arguments:
   -h, --help            Show this help message and exit.
   -v, --version         Show program's version number and exit.
-  --username USERNAME   Okta username (ex. user@meetearnest.com)
+  --username USERNAME   Okta username (ex. user@domain.com)
   --password PASSWORD   Okta password
   --role ROLE           Name of SAML role to assume
   --account {staging,development}
@@ -93,6 +70,52 @@ We're using headless browser automation to emulate a form-based sign-on. This is
  6. Present accessible roles to the user (if more than one) and allow them to select the role to assume
  7. Use the STS API to [assume the role](http://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-saml.html)
  8. Save the token information to the [AWS credentials file](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs)
+
+
+## Setting up the AWS Token Generator for your Organization
+
+We recommend the following steps for use in your organization, see `example`:
+
+1. Create a fresh git repository/dir
+2. Copy [`config.example.json`](./cfg/config.example.json) to the root of your repository/dir as `config.json` and edit it for your organization
+3. Create a Dockerfile for your token generator. The following should suffice:
+
+    ```
+    FROM $ORG/aws-sts:config
+    ```
+
+4. Build and publish the docker image for use in your organization
+5. Copy the [`aws-token`](./example/aws-token) script to your prefered PATH location e.g. `/usr/local/bin/aws-token`
+6. in your terminal do a `$ aws-token` to generate a temporal AWS token
+
+## Configuration
+
+Configuration is done by creating a config.json file in the root of your repository. An [example template](./cfg/config.example.json) is provided.
+
+```
+awsConfigPath:    Path to the user AWS CLI credential file. The recommended path is the path to the
+                  Docker container's credential path.
+outputFormat:     Output format of AWS access token credentials
+region:           Region used for AWS API calls
+provider:         Name of the SAML provider to use for authentication
+idPEntryUrl:      URL to access the form-based authentication login for the provider
+defaultAccount:   Default AWS account to use when one is not specified via the command line
+accounts:         Map of accountName/account-objects for accounts which can be switched to
+                  once initially authenticated
+  account:
+    accountNumber: AWS account number
+    idpEntryUrl:   URL to access the form-based authentication login for the provider. If not defined will
+                   fallback to the global idPEntryUrl
+```
+
+## Building
+
+Once configured, build a docker container so that folks on your team can easily generate tokens without setup or configuration.
+
+```
+docker-compose build
+docker-compose push
+```
 
 ## Found a bug?
 

--- a/aws-token.example.sh
+++ b/aws-token.example.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-ORG="YOUR_DOCKER_ORG_NAME_HERE"
-
-docker run -it --rm -v $HOME/.aws/:/root/.aws/ ${ORG}/aws-sts "$@"

--- a/cfg/config.example.json
+++ b/cfg/config.example.json
@@ -3,10 +3,19 @@
   "outputFormat": "json",
   "region": "us-east-1",
   "provider": "okta",
-  "idpEntryUrl": "https://xxx.okta.com/home/amazon_aws/xxx",
   "accounts": {
-    "staging": "aws-account-id",
-    "production": "aws-account-id"
+    "development": {
+      "accountNumber": "aws-account-id",
+      "idpEntryUrl": "https://xxx.okta.com/home/amazon_aws/xxx"
+    },
+    "staging": {
+      "accountNumber": "aws-account-id",
+      "idpEntryUrl": "https://xxx.okta.com/home/amazon_aws/xxx"
+    },
+    "production": {
+      "accountNumber": "aws-account-id",
+      "idpEntryUrl": "https://xxx.okta.com/home/amazon_aws/xxx"
+    }
   },
   "defaultAccount": "staging"
 }

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,0 +1,1 @@
+FROM ${ORG}/aws-sts:base

--- a/example/aws-token
+++ b/example/aws-token
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ORG="YOUR_DOCKER_ORG_NAME_HERE"
+
+docker run \
+  -it --rm \
+  -v $HOME/.aws/:/root/.aws/ \
+  $ORG/aws-sts:config \
+  "$@"

--- a/example/build.sh
+++ b/example/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ORG="YOUR_DOCKER_ORG_NAME_HERE"
+
+docker build  -t $ORG/aws-sts:config .

--- a/example/config.json
+++ b/example/config.json
@@ -1,0 +1,21 @@
+{
+  "awsConfigPath": "/.aws/credentials",
+  "outputFormat": "json",
+  "region": "us-east-1",
+  "provider": "okta",
+  "accounts": {
+    "development": {
+      "accountNumber": "747722827777",
+      "idpEntryUrl": "https://dev-777777.okta.com/home/amazon_aws/XXXXXXXXXXXXXX/272"
+    },
+    "staging": {
+      "accountNumber": "747722827777",
+      "idpEntryUrl": "https://dev-777777.okta.com/home/amazon_aws/XXXXXXXXXXXXXX/272"
+    },
+    "production": {
+      "accountNumber": "747722827777",
+      "idpEntryUrl": "https://dev-777777.okta.com/home/amazon_aws/XXXXXXXXXXXXXX/272"
+    }
+  },
+  "defaultAccount": "development"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,10 @@ co(function *() {
   const provider = require(`./providers/${config.provider}`);
   const args = parseArgs(provider.name);
   const tokenGetter = new TokenGetter(config);
-  const accountNumber = config.accounts[args.account];
-  const account = {accountNumber, name: args.account};
+  const account = config.accounts[args.account];
+  const idpEntryUrl = account.idpEntryUrl ? account.idpEntryUrl : config.idpEntryUrl;
 
-  const samlAssertion = yield provider.login(config.idpEntryUrl, args.username, args.password);
+  const samlAssertion = yield provider.login(idpEntryUrl, args.username, args.password);
   const role = yield selectRole(samlAssertion, args.role);
   const token = yield tokenGetter.getToken(samlAssertion, account, role);
   const profileName = buildProfileName(role, account.name, args.profile);

--- a/src/token-getter.js
+++ b/src/token-getter.js
@@ -20,7 +20,9 @@ class TokenGetter {
       this.spinner.start();
       const token = await this.getSTSToken();
 
-      if (this.isDefaultAccount()) {
+      // if the account has an IDP field we don't care about the default account
+      // because we loged in directly to the final account
+      if (this.isDefaultAccount() || this.hasAccountIDP()) {
         this.spinner.stop();
         return token;
       }
@@ -37,6 +39,10 @@ class TokenGetter {
 
   isDefaultAccount() {
     return this.account.name === this.defaultAccount;
+  }
+
+  hasAccountIDP() {
+    return 'idpEntryUrl' in this.account;
   }
 
   async getSTSToken() {


### PR DESCRIPTION
Adds support for the upcoming changes in the "IAM Role Refresh" project which involves splitting the  AWS Okta application to one per account instead of one for all account.

This impacts some logic in the STS script since we are now not proxying from the tools account.

The changes in this PR enable to get the STS token for both the previous setup and the new setup.

there are **BREAKING CHANGES**, the configuration accounts were previously defined as:

```
"accounts": {
    "development": "aws-account-id",
    "staging": "aws-account-id",
    ...
  },
```

and now, the account items were upgraded to an object, with fields `accountNumber` and `idpEntryUrl`.

```
"accounts": {
    "development": {
      "accountNumber": "aws-account-id",
      "idpEntryUrl": "https://xxx.okta.com/home/amazon_aws/xxx"
    },
    "staging": {
      "accountNumber": "aws-account-id",
      "idpEntryUrl": "https://xxx.okta.com/home/amazon_aws/xxx"
    },
    ...
  },
```

The compatibility is maintained by falling back to the `config.idpEntryUrl` and doing the proxy thing if the account does not have the `idpEntryUrl` key defined.
